### PR TITLE
Updated node_helper.js, Added CSS, Updates Every 6 Hours

### DIFF
--- a/MMM-eswordoftheday.css
+++ b/MMM-eswordoftheday.css
@@ -1,0 +1,3 @@
+.example-spacing {
+    padding-top: 10px; /* Adjust this value as needed */
+  }

--- a/MMM-eswordoftheday.js
+++ b/MMM-eswordoftheday.js
@@ -9,11 +9,7 @@ Module.register("MMM-eswordoftheday", {
   start: function () {
     Log.info(`Starting module: ${this.name}`)
     this.apiData = null
-
-    // Fetch initial data
     this.sendSocketNotification("MMM-eswordoftheday-GET_WORD", {})
-
-    // Fetch every 6 hours (or custom interval)
     setInterval(() => {
       this.sendSocketNotification("MMM-eswordoftheday-GET_WORD", {})
     }, this.config.updateInterval)
@@ -23,6 +19,10 @@ Module.register("MMM-eswordoftheday", {
     return "Spanish Word of the Day"
   },
 
+  getStyles: function () {
+    return ["MMM-eswordoftheday.css"]
+  },
+
   socketNotificationReceived: function (notification, payload) {
     if (notification === "MMM-eswordoftheday-RETURN_WORD") {
       Log.info("Received:", payload)
@@ -30,43 +30,40 @@ Module.register("MMM-eswordoftheday", {
       this.updateDom()
     }
   },
-  getStyles: function () {
-    return ["MMM-eswordoftheday.css"]
-  },
-  
+
   getDom: function () {
     const wrapper = document.createElement("div")
-  
+
     if (this.apiData) {
       const word = document.createElement("div")
       word.innerHTML = this.apiData.word
       word.className = "bold large"
       wrapper.appendChild(word)
-  
+
       const translation = document.createElement("div")
       translation.innerHTML = this.apiData.translation
       wrapper.appendChild(translation)
-  
+
       if (this.config.showExamples && this.apiData.spanishExample) {
         const exampleContainer = document.createElement("div")
-        exampleContainer.className = "small example-spacing" // Add custom class
-  
+        exampleContainer.className = "small example-spacing"
+
         const es = document.createElement("div")
         es.innerHTML = this.apiData.spanishExample || "."
         exampleContainer.appendChild(es)
-  
+
         if (this.config.showExampleTranslations && this.apiData.englishExample) {
           const en = document.createElement("div")
           en.innerHTML = this.apiData.englishExample || "."
           exampleContainer.appendChild(en)
         }
-  
+
         wrapper.appendChild(exampleContainer)
       }
     } else {
       wrapper.innerHTML = "Loading..."
     }
-  
+
     return wrapper
   },
 })

--- a/MMM-eswordoftheday.js
+++ b/MMM-eswordoftheday.js
@@ -1,6 +1,6 @@
 Module.register("MMM-eswordoftheday", {
   defaults: {
-    updateInterval: 86400000,
+    updateInterval: 6 * 60 * 60 * 1000, // 6 hours in milliseconds
     retryDelay: 5000,
     showExamples: true,
     showExampleTranslations: true,
@@ -8,14 +8,14 @@ Module.register("MMM-eswordoftheday", {
 
   start: function () {
     Log.info(`Starting module: ${this.name}`)
-
     this.apiData = null
 
-    this.sendSocketNotification("MMM-eswordoftheday-GET_WORD", null)
+    // Fetch initial data
+    this.sendSocketNotification("MMM-eswordoftheday-GET_WORD", {})
 
-    const self = this
-    setTimeout(function () {
-      self.sendSocketNotification("MMM-eswordoftheday-GET_WORD", null)
+    // Fetch every 6 hours (or custom interval)
+    setInterval(() => {
+      this.sendSocketNotification("MMM-eswordoftheday-GET_WORD", {})
     }, this.config.updateInterval)
   },
 
@@ -25,7 +25,7 @@ Module.register("MMM-eswordoftheday", {
 
   socketNotificationReceived: function (notification, payload) {
     if (notification === "MMM-eswordoftheday-RETURN_WORD") {
-      Log.info("recieved: ", payload)
+      Log.info("Received:", payload)
       this.apiData = payload
       this.updateDom()
     }
@@ -44,24 +44,23 @@ Module.register("MMM-eswordoftheday", {
       translation.innerHTML = this.apiData.translation
       wrapper.appendChild(translation)
 
-      if (this.config.showExamples) {
+      if (this.config.showExamples && this.apiData.spanishExample) {
         const list = document.createElement("ul")
         list.className = "small"
 
         const listItem = document.createElement("li")
 
         const es = document.createElement("div")
-        es.innerHTML = this.apiData.spanishExample
+        es.innerHTML = this.apiData.spanishExample || "."
         listItem.appendChild(es)
 
-        if (this.config.showExampleTranslations) {
+        if (this.config.showExampleTranslations && this.apiData.englishExample) {
           const en = document.createElement("div")
-          en.innerHTML = this.apiData.englishExample
+          en.innerHTML = this.apiData.englishExample || "."
           listItem.appendChild(en)
         }
 
         list.appendChild(listItem)
-
         wrapper.appendChild(list)
       }
     } else {

--- a/MMM-eswordoftheday.js
+++ b/MMM-eswordoftheday.js
@@ -30,43 +30,43 @@ Module.register("MMM-eswordoftheday", {
       this.updateDom()
     }
   },
-
+  getStyles: function () {
+    return ["MMM-eswordoftheday.css"]
+  },
+  
   getDom: function () {
     const wrapper = document.createElement("div")
-
+  
     if (this.apiData) {
       const word = document.createElement("div")
       word.innerHTML = this.apiData.word
       word.className = "bold large"
       wrapper.appendChild(word)
-
+  
       const translation = document.createElement("div")
       translation.innerHTML = this.apiData.translation
       wrapper.appendChild(translation)
-
+  
       if (this.config.showExamples && this.apiData.spanishExample) {
-        const list = document.createElement("ul")
-        list.className = "small"
-
-        const listItem = document.createElement("li")
-
+        const exampleContainer = document.createElement("div")
+        exampleContainer.className = "small example-spacing" // Add custom class
+  
         const es = document.createElement("div")
         es.innerHTML = this.apiData.spanishExample || "."
-        listItem.appendChild(es)
-
+        exampleContainer.appendChild(es)
+  
         if (this.config.showExampleTranslations && this.apiData.englishExample) {
           const en = document.createElement("div")
           en.innerHTML = this.apiData.englishExample || "."
-          listItem.appendChild(en)
+          exampleContainer.appendChild(en)
         }
-
-        list.appendChild(listItem)
-        wrapper.appendChild(list)
+  
+        wrapper.appendChild(exampleContainer)
       }
     } else {
       wrapper.innerHTML = "Loading..."
     }
-
+  
     return wrapper
   },
 })

--- a/node_helper.js
+++ b/node_helper.js
@@ -15,9 +15,14 @@ module.exports = NodeHelper.create({
 
         const translation = wotdContainer.next().text()
 
-        const examples = $("li").first().children()
-        const spanishExample = examples.first("div").contents().first().text()
-        const englishExample = examples.last("div").contents().first().text()
+        let spanishExample = ''
+        let englishExample = ''
+        const exampleContainer = $('.YRbPpWPt').first()
+
+        if (exampleContainer.length) {
+          spanishExample = exampleContainer.find('.jxXGMKma').text().trim()
+          englishExample = exampleContainer.find('.B8zBqhO4').text().trim().replace(/^.*—\s*/, '') // Remove "—" and preceding whitespace
+        }
 
         const translationData = {
           word: wotd,
@@ -26,11 +31,14 @@ module.exports = NodeHelper.create({
           englishExample: englishExample,
         }
 
-        // Send Data
+        console.log("Fetched data:", translationData)
+
         this.sendSocketNotification(
           "MMM-eswordoftheday-RETURN_WORD",
           translationData
         )
+      }).catch(error => {
+        console.error("Error fetching data:", error)
       })
     }
   },


### PR DESCRIPTION
The original website being scraped by the module has been updated by the developers. The word of the day and the English meaning of the word would pull correctly; adversely, the Spanish example and the English example would not populate due to the "https://www.spanishdict.com/wordoftheday" webpage being updated. This version updates the two examples to show correctly by:

- Updated node_helper.js to direct module to the proper section of the https://www.spanishdict.com/wordoftheday website. The word and translation would populate, but the examples did not. 
- Deleted the bullet points by changing the <ul> and <li> elements to <div>. 
   - Added CSS file and proper coding in the .js file to reference properly. Once the <ul> was deleted, the padding above the Spanish example versus the bottom of the English translation were tight with 0 pixels. The CSS file addresses this and corrects it. Add or remove pixels to your liking. 
- Updated the timeframe from 24 hours to 6 hours to scrape the website to update the word of the day in case of MM restart. 